### PR TITLE
Fix building with `rapier` and `debug_draw` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ categories = ["game-development"]
 
 [features]
 default = []
-rapier = ["bevy_rapier3d"]
+rapier = ["bevy_rapier3d", "bevy/bevy_render"]
 xpbd = ["bevy_xpbd_3d"]
-debug_draw = ["bevy/bevy_gizmos"]
+debug_draw = ["bevy/bevy_gizmos", "bevy/bevy_render"]
 trace = []
 
 [[example]]


### PR DESCRIPTION
`bevy_render` feature of bevy is now enabled for these features to fix an error when building. Will also fix the docs.rs build.

Side note: please specify docs.rs as the documentation page in the Cargo.toml, it would make it much easier for people to find it.