### PR TITLE
Rapier 0.26.0 support!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,9 @@ categories = ["game-development"]
 
 [features]
 default = []
-rapier = ["bevy_rapier3d"]
+rapier = ["bevy_rapier3d", "parry3d_rapier" ]
 xpbd = ["bevy_xpbd_3d", "parry3d_xpbd"]
+parry_standalone = ["parry3d_rapier"]
 debug_draw = ["bevy/bevy_gizmos", "bevy/bevy_render"]
 trace = []
 
@@ -61,7 +62,7 @@ nalgebra = { version = "0.32", features = ["convert-glam025"] }
 
 # different parry3d versions depending on physics implementation
 parry3d_xpbd = { package = "parry3d", version = "0.13", optional = true }
-parry3d_rapier = { package = "parry3d", version = "0.15.1"}
+parry3d_rapier = { package = "parry3d", version = "0.15.1", optional = true}
 
 bevy_rapier3d = { version = "0.26.0", optional = true, default-features = false, features = ["dim3"] }
 bevy_xpbd_3d = { version = "0.4", optional = true, default-features = false, features = ["3d", "f32", "parry-f32"]  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ categories = ["game-development"]
 
 [features]
 default = []
-rapier = ["bevy_rapier3d"]
-xpbd = ["bevy_xpbd_3d"]
+rapier = ["bevy_rapier3d", "parry3d_rapier"]
+xpbd = ["bevy_xpbd_3d", "parry3d_xpbd"]
 debug_draw = ["bevy/bevy_gizmos", "bevy/bevy_render"]
 trace = []
 
@@ -58,12 +58,16 @@ bevy = { version = "0.13", default-features = false, features = ["multi-threaded
 
 # parry3d doesn't expose the convert-glam feature, so we need to add nalgebra to enable the feature
 nalgebra = { version = "0.32", features = ["convert-glam025"] }
-parry3d = "0.13"
 
-bevy_rapier3d = { version = "0.25", optional = true, default-features = false, features = ["dim3"] }
+# different parry3d versions depending on physics implementation
+parry3d_xpbd = { package = "parry3d", version = "0.13", optional = true }
+parry3d_rapier = { package = "parry3d", version = "0.15.1", optional = true }
+
+bevy_rapier3d = { version = "0.26.0", optional = true, default-features = false, features = ["dim3"] }
 bevy_xpbd_3d = { version = "0.4", optional = true, default-features = false, features = ["3d", "f32", "parry-f32"]  }
 
 smallvec = { version = "1.13", features = ["union"] }
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 bevy = { version = "0.13", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["game-development"]
 
 [features]
 default = []
-rapier = []
+rapier = ["bevy_rapier3d"]
 xpbd = ["bevy_xpbd_3d", "parry3d_xpbd"]
 debug_draw = ["bevy/bevy_gizmos", "bevy/bevy_render"]
 trace = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["game-development"]
 
 [features]
 default = []
-rapier = ["bevy_rapier3d", "parry3d_rapier"]
+rapier = []
 xpbd = ["bevy_xpbd_3d", "parry3d_xpbd"]
 debug_draw = ["bevy/bevy_gizmos", "bevy/bevy_render"]
 trace = []
@@ -61,7 +61,7 @@ nalgebra = { version = "0.32", features = ["convert-glam025"] }
 
 # different parry3d versions depending on physics implementation
 parry3d_xpbd = { package = "parry3d", version = "0.13", optional = true }
-parry3d_rapier = { package = "parry3d", version = "0.15.1", optional = true }
+parry3d_rapier = { package = "parry3d", version = "0.15.1"}
 
 bevy_rapier3d = { version = "0.26.0", optional = true, default-features = false, features = ["dim3"] }
 bevy_xpbd_3d = { version = "0.4", optional = true, default-features = false, features = ["3d", "f32", "parry-f32"]  }

--- a/examples/parry3d.rs
+++ b/examples/parry3d.rs
@@ -1,11 +1,14 @@
 //! A simple example showing how to use oxidized_navigation with a custom component using parry3d colliders.
 
 use bevy::{math::primitives, prelude::*};
+
 use oxidized_navigation::{
     colliders::OxidizedCollider,
     debug_draw::{DrawNavMesh, OxidizedNavigationDebugDrawPlugin},
     NavMeshAffector, NavMeshSettings, OxidizedNavigationPlugin,
 };
+
+use parry3d_rapier as parry3d;
 use parry3d::shape::SharedShape;
 
 fn main() {

--- a/examples/rapier3d.rs
+++ b/examples/rapier3d.rs
@@ -14,6 +14,7 @@ use bevy::{
 };
 // use bevy_editor_pls::EditorPlugin;
 use bevy::tasks::futures_lite::future;
+use bevy_rapier3d::plugin::TimestepMode;
 use bevy_rapier3d::prelude::{Collider, NoUserData, RapierConfiguration, RapierPhysicsPlugin};
 use oxidized_navigation::{
     debug_draw::{DrawNavMesh, DrawPath, OxidizedNavigationDebugDrawPlugin},
@@ -35,9 +36,15 @@ fn main() {
             // An example of this is the "Thin Wall" in [setup_world_system]. If you remove this plugin, it will not appear correctly.
             RapierPhysicsPlugin::<NoUserData>::default(),
         ))
+        //This was previously setting the pipeline to false, then using ..default, however the default seems to be gone for RapierConfiguration
+        // As of 0.26.0. --Baron Von Scrub
         .insert_resource(RapierConfiguration {
+            gravity: Default::default(),
             physics_pipeline_active: false,
-            ..Default::default()
+            query_pipeline_active: false,
+            timestep_mode: TimestepMode::Fixed{ dt: 0.1, substeps: 1 },
+            scaled_shape_subdivision: 0,
+            force_update_from_transform_changes: false,
         })
         .insert_resource(AsyncPathfindingTasks::default())
         .add_systems(Startup, setup_world_system)

--- a/examples/rapier3d_heightfield.rs
+++ b/examples/rapier3d_heightfield.rs
@@ -13,6 +13,7 @@ use bevy::{
     prelude::*,
     tasks::{AsyncComputeTaskPool, Task},
 };
+use bevy_rapier3d::plugin::TimestepMode;
 use bevy_rapier3d::prelude::{Collider, NoUserData, RapierConfiguration, RapierPhysicsPlugin};
 use oxidized_navigation::{
     debug_draw::{DrawNavMesh, DrawPath, OxidizedNavigationDebugDrawPlugin},
@@ -33,9 +34,15 @@ fn main() {
             // An example of this is the "Thin Wall" in [setup_world_system]. If you remove this plugin, it will not appear correctly.
             RapierPhysicsPlugin::<NoUserData>::default(),
         ))
+        //This was previously setting the pipeline to false, then using ..default, however the default seems to be gone for RapierConfiguration
+        // As of 0.26.0. --Baron Von Scrub
         .insert_resource(RapierConfiguration {
+            gravity: Default::default(),
             physics_pipeline_active: false,
-            ..Default::default()
+            query_pipeline_active: false,
+            timestep_mode: TimestepMode::Fixed{ dt: 0.1, substeps: 1 },
+            scaled_shape_subdivision: 0,
+            force_update_from_transform_changes: false,
         })
         .insert_resource(AsyncPathfindingTasks::default())
         .add_systems(Startup, (setup_world_system, info_system))

--- a/examples/rapier3d_multi_floor.rs
+++ b/examples/rapier3d_multi_floor.rs
@@ -13,6 +13,7 @@ use bevy::{
 };
 // use bevy_editor_pls::EditorPlugin;
 use bevy::tasks::futures_lite::future;
+use bevy_rapier3d::plugin::TimestepMode;
 use bevy_rapier3d::prelude::{Collider, NoUserData, RapierConfiguration, RapierPhysicsPlugin};
 use oxidized_navigation::{
     debug_draw::{DrawNavMesh, DrawPath, OxidizedNavigationDebugDrawPlugin},
@@ -34,9 +35,15 @@ fn main() {
             // An example of this is the "Thin Wall" in [setup_world_system]. If you remove this plugin, it will not appear correctly.
             RapierPhysicsPlugin::<NoUserData>::default(),
         ))
+        //This was previously setting the pipeline to false, then using ..default, however the default seems to be gone for RapierConfiguration
+        // As of 0.26.0. --Baron Von Scrub
         .insert_resource(RapierConfiguration {
+            gravity: Default::default(),
             physics_pipeline_active: false,
-            ..Default::default()
+            query_pipeline_active: false,
+            timestep_mode: TimestepMode::Fixed{ dt: 0.1, substeps: 1 },
+            scaled_shape_subdivision: 0,
+            force_update_from_transform_changes: false,
         })
         .insert_resource(AsyncPathfindingTasks::default())
         .add_systems(Startup, setup_world_system)

--- a/src/colliders/mod.rs
+++ b/src/colliders/mod.rs
@@ -1,4 +1,13 @@
 use bevy::prelude::Component;
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "xpbd")] {
+        use parry3d_xpbd as parry3d;
+    } else if #[cfg(feature = "rapier")] {
+        use parry3d_rapier as parry3d;
+    }
+}
 
 #[cfg(feature = "rapier")]
 pub mod rapier;

--- a/src/colliders/mod.rs
+++ b/src/colliders/mod.rs
@@ -1,13 +1,7 @@
 use bevy::prelude::Component;
-use cfg_if::cfg_if;
+use crate::use_appropriate_parry3d;
 
-cfg_if! {
-    if #[cfg(feature = "xpbd")] {
-        use parry3d_xpbd as parry3d;
-    } else {
-        use parry3d_rapier as parry3d;
-    }
-}
+use_appropriate_parry3d!();
 
 #[cfg(feature = "rapier")]
 pub mod rapier;

--- a/src/colliders/mod.rs
+++ b/src/colliders/mod.rs
@@ -4,7 +4,7 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(feature = "xpbd")] {
         use parry3d_xpbd as parry3d;
-    } else if #[cfg(feature = "rapier")] {
+    } else {
         use parry3d_rapier as parry3d;
     }
 }

--- a/src/colliders/rapier.rs
+++ b/src/colliders/rapier.rs
@@ -1,3 +1,5 @@
+use parry3d_rapier as parry3d;
+
 use parry3d::{bounding_volume::Aabb, shape::TypedShape};
 
 use super::OxidizedCollider;

--- a/src/colliders/xpbd.rs
+++ b/src/colliders/xpbd.rs
@@ -1,3 +1,5 @@
+use parry3d_xpbd as parry3d;
+
 use parry3d::{bounding_volume::Aabb, shape::TypedShape};
 
 use super::OxidizedCollider;

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,4 +1,14 @@
 use bevy::prelude::{Transform, Vec3};
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "xpbd")] {
+        use parry3d_xpbd as parry3d;
+    } else if #[cfg(feature = "rapier")] {
+        use parry3d_rapier as parry3d;
+    }
+}
+
 use parry3d::{
     math::Real,
     na::Point3,

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -4,7 +4,7 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(feature = "xpbd")] {
         use parry3d_xpbd as parry3d;
-    } else if #[cfg(feature = "rapier")] {
+    } else {
         use parry3d_rapier as parry3d;
     }
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,13 +1,6 @@
 use bevy::prelude::{Transform, Vec3};
-use cfg_if::cfg_if;
 
-cfg_if! {
-    if #[cfg(feature = "xpbd")] {
-        use parry3d_xpbd as parry3d;
-    } else {
-        use parry3d_rapier as parry3d;
-    }
-}
+use_appropriate_parry3d!();
 
 use parry3d::{
     math::Real,
@@ -15,7 +8,7 @@ use parry3d::{
     shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Triangle},
 };
 
-use crate::{heightfields::TriangleCollection, Area};
+use crate::{heightfields::TriangleCollection, Area, use_appropriate_parry3d};
 
 pub struct GeometryCollection {
     pub transform: Transform,

--- a/src/heightfields.rs
+++ b/src/heightfields.rs
@@ -1,15 +1,9 @@
 use std::{cmp::Ordering, ops::Div, sync::Arc};
 
 use bevy::{math::Vec3A, prelude::*};
-use cfg_if::cfg_if;
 
-cfg_if! {
-    if #[cfg(feature = "xpbd")] {
-        use parry3d_xpbd as parry3d;
-    } else {
-        use parry3d_rapier as parry3d;
-    }
-}
+use crate::use_appropriate_parry3d;
+use_appropriate_parry3d!();
 
 use parry3d::shape::HeightField;
 use smallvec::SmallVec;

--- a/src/heightfields.rs
+++ b/src/heightfields.rs
@@ -6,7 +6,7 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(feature = "xpbd")] {
         use parry3d_xpbd as parry3d;
-    } else if #[cfg(feature = "rapier")] {
+    } else {
         use parry3d_rapier as parry3d;
     }
 }

--- a/src/heightfields.rs
+++ b/src/heightfields.rs
@@ -1,6 +1,16 @@
 use std::{cmp::Ordering, ops::Div, sync::Arc};
 
 use bevy::{math::Vec3A, prelude::*};
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "xpbd")] {
+        use parry3d_xpbd as parry3d;
+    } else if #[cfg(feature = "rapier")] {
+        use parry3d_rapier as parry3d;
+    }
+}
+
 use parry3d::shape::HeightField;
 use smallvec::SmallVec;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ use bevy::{
     prelude::*,
     utils::{HashMap, HashSet},
 };
-use cfg_if::cfg_if;
 use colliders::OxidizedCollider;
 use contour::build_contours;
 use conversion::{
@@ -66,13 +65,8 @@ use heightfields::{
 };
 use mesher::build_poly_mesh;
 
-cfg_if! {
-    if #[cfg(feature = "xpbd")] {
-        use parry3d_xpbd as parry3d;
-    } else {
-        use parry3d_rapier as parry3d;
-    }
-}
+mod parry3d_macro;
+use_appropriate_parry3d!();
 
 use parry3d::math::Isometry;
 use parry3d::na::Vector3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ use mesher::build_poly_mesh;
 cfg_if! {
     if #[cfg(feature = "xpbd")] {
         use parry3d_xpbd as parry3d;
-    } else if #[cfg(feature = "rapier")] {
+    } else {
         use parry3d_rapier as parry3d;
     }
 }

--- a/src/parry3d_macro.rs
+++ b/src/parry3d_macro.rs
@@ -1,0 +1,22 @@
+#[macro_export]
+macro_rules! use_appropriate_parry3d {
+    () => {
+        cfg_if::cfg_if! {
+            if #[cfg(all(feature = "xpbd", feature = "rapier"))] {
+                compile_error!("Features 'xpbd' and 'rapier' cannot be enabled at the same time.");
+            } else if #[cfg(all(feature = "xpbd", feature = "parry_standalone"))] {
+                compile_error!("Features 'xpbd' and 'parry_standalone' cannot be enabled at the same time.");
+            } else if #[cfg(all(feature = "rapier", feature = "parry_standalone"))] {
+                compile_error!("Features 'rapier' and 'parry_standalone' cannot be enabled at the same time.");
+            } else if #[cfg(feature = "xpbd")] {
+                use parry3d_xpbd as parry3d;
+            } else if #[cfg(feature = "rapier")] {
+                use parry3d_rapier as parry3d;
+            } else if #[cfg(feature = "parry_standalone")] {
+                use parry3d_rapier as parry3d;
+            } else {
+                compile_error!("One of the features 'xpbd', 'rapier', or 'parry_standalone' must be enabled.");
+            }
+        }
+    };
+}

--- a/tests/parry3d.rs
+++ b/tests/parry3d.rs
@@ -1,12 +1,20 @@
 use std::{num::NonZeroU16, time::Duration};
 
 use bevy::prelude::*;
+use cfg_if::cfg_if;
 use oxidized_navigation::{
     colliders::OxidizedCollider, query::find_path, ActiveGenerationTasks, NavMesh, NavMeshAffector,
     NavMeshSettings, OxidizedNavigationPlugin,
 };
 
-use parry3d_rapier as parry3d;
+cfg_if! {
+    if #[cfg(feature = "xpbd")] {
+        use parry3d_xpbd as parry3d;
+    } else {
+        use parry3d_rapier as parry3d;
+    }
+}
+
 use parry3d::shape::SharedShape;
 
 const TIMEOUT_DURATION: Duration = Duration::new(15, 0);

--- a/tests/parry3d.rs
+++ b/tests/parry3d.rs
@@ -1,19 +1,9 @@
 use std::{num::NonZeroU16, time::Duration};
 
 use bevy::prelude::*;
-use cfg_if::cfg_if;
-use oxidized_navigation::{
-    colliders::OxidizedCollider, query::find_path, ActiveGenerationTasks, NavMesh, NavMeshAffector,
-    NavMeshSettings, OxidizedNavigationPlugin,
-};
+use oxidized_navigation::{colliders::OxidizedCollider, query::find_path, ActiveGenerationTasks, NavMesh, NavMeshAffector, NavMeshSettings, OxidizedNavigationPlugin, use_appropriate_parry3d};
 
-cfg_if! {
-    if #[cfg(feature = "xpbd")] {
-        use parry3d_xpbd as parry3d;
-    } else {
-        use parry3d_rapier as parry3d;
-    }
-}
+use_appropriate_parry3d!();
 
 use parry3d::shape::SharedShape;
 

--- a/tests/parry3d.rs
+++ b/tests/parry3d.rs
@@ -5,6 +5,8 @@ use oxidized_navigation::{
     colliders::OxidizedCollider, query::find_path, ActiveGenerationTasks, NavMesh, NavMeshAffector,
     NavMeshSettings, OxidizedNavigationPlugin,
 };
+
+use parry3d_rapier as parry3d;
 use parry3d::shape::SharedShape;
 
 const TIMEOUT_DURATION: Duration = Duration::new(15, 0);


### PR DESCRIPTION
Added compatibility with Rapier 0.26.0 whilst maintaining xpbd compatibility. Example functionality seems 1:1 as before, and test is passed.

Note that Rapier and XPBD features are now mutually exclusive, if they weren't before, due to differing versions of Parry3D.