### PR TITLE
Fix rust-analyzer crashing on Unix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "rust-analyzer.linkedProjects": [
-        ".\\Cargo.toml"
+        "./Cargo.toml"
     ],
     "rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,7 +573,7 @@ fn can_generate_new_tiles(
 ) -> bool {
     nav_mesh_settings
         .max_tile_generation_tasks
-        .map_or(true, |max_tile_generation_tasks| {
+        .is_none_or(|max_tile_generation_tasks| {
             active_generation_tasks.0.len() < max_tile_generation_tasks.get().into()
         })
         && !dirty_tiles.0.is_empty()


### PR DESCRIPTION
Windows doesn't mind `/`, so this should still work there.
Side note, I don't think that this setting does anything, as `./Cargo.toml` is already in the root by definition when opening the project. Still left it in there, Chesterton's fence and all