### PR TITLE
Change the OxidizedCollider trait to take a ReadOnlyQueryData instead of a component.

### DIFF
--- a/examples/avian.rs
+++ b/examples/avian.rs
@@ -5,6 +5,7 @@
 use avian3d::prelude::{Collider, PhysicsPlugins};
 use bevy::{math::primitives, prelude::*};
 use oxidized_navigation::{
+    colliders::avian::AvianCollider,
     debug_draw::{DrawNavMesh, OxidizedNavigationDebugDrawPlugin},
     NavMeshAffector, NavMeshSettings, OxidizedNavigationPlugin,
 };
@@ -20,7 +21,7 @@ fn main() {
                 }),
                 ..default()
             }),
-            OxidizedNavigationPlugin::<Collider>::new(NavMeshSettings::from_agent_and_bounds(
+            OxidizedNavigationPlugin::<AvianCollider>::new(NavMeshSettings::from_agent_and_bounds(
                 0.5, 1.9, 250.0, -1.0,
             )),
             OxidizedNavigationDebugDrawPlugin,

--- a/examples/avian_multi_floor.rs
+++ b/examples/avian_multi_floor.rs
@@ -14,6 +14,7 @@ use bevy::{
     tasks::{AsyncComputeTaskPool, Task},
 };
 use oxidized_navigation::{
+    colliders::avian::AvianCollider,
     debug_draw::{DrawNavMesh, DrawPath, OxidizedNavigationDebugDrawPlugin},
     query::{find_path, find_polygon_path, perform_string_pulling_on_path},
     tiles::NavMeshTiles,
@@ -32,7 +33,7 @@ fn main() {
                 }),
                 ..default()
             }),
-            OxidizedNavigationPlugin::<Collider>::new(NavMeshSettings::from_agent_and_bounds(
+            OxidizedNavigationPlugin::<AvianCollider>::new(NavMeshSettings::from_agent_and_bounds(
                 0.5, 1.9, 250.0, -1.0,
             )),
             OxidizedNavigationDebugDrawPlugin,

--- a/examples/parry3d.rs
+++ b/examples/parry3d.rs
@@ -42,12 +42,14 @@ struct MyParryCollider {
 }
 
 impl OxidizedCollider for MyParryCollider {
-    fn oxidized_into_typed_shape(&self) -> TypedShape {
-        self.collider.as_typed_shape()
+    type Component = MyParryCollider;
+
+    fn oxidized_into_typed_shape(collider: &Self) -> TypedShape {
+        collider.collider.as_typed_shape()
     }
 
-    fn oxidized_compute_local_aabb(&self) -> Aabb {
-        self.collider.compute_local_aabb()
+    fn oxidized_compute_local_aabb(collider: &Self) -> Aabb {
+        collider.collider.compute_local_aabb()
     }
 }
 

--- a/examples/rapier3d.rs
+++ b/examples/rapier3d.rs
@@ -17,6 +17,7 @@ use bevy::{
 use bevy::tasks::futures_lite::future;
 use bevy_rapier3d::prelude::{Collider, NoUserData, RapierPhysicsPlugin};
 use oxidized_navigation::{
+    colliders::rapier::RapierCollider,
     debug_draw::{DrawNavMesh, DrawPath, OxidizedNavigationDebugDrawPlugin},
     query::{find_path, find_polygon_path, perform_string_pulling_on_path},
     tiles::NavMeshTiles,
@@ -34,9 +35,9 @@ fn main() {
                 }),
                 ..default()
             }),
-            OxidizedNavigationPlugin::<Collider>::new(NavMeshSettings::from_agent_and_bounds(
-                0.5, 1.9, 250.0, -1.0,
-            )),
+            OxidizedNavigationPlugin::<RapierCollider>::new(
+                NavMeshSettings::from_agent_and_bounds(0.5, 1.9, 250.0, -1.0),
+            ),
             OxidizedNavigationDebugDrawPlugin,
             // The rapier plugin needs to be added for the scales of colliders to be correct if the scale of the entity is not uniformly 1.
             // An example of this is the "Thin Wall" in [setup_world_system]. If you remove this plugin, it will not appear correctly.

--- a/examples/rapier3d_heightfield.rs
+++ b/examples/rapier3d_heightfield.rs
@@ -20,6 +20,7 @@ use bevy_rapier3d::prelude::{Collider, NoUserData, RapierPhysicsPlugin};
 use bevy_rapier3d::render::RapierDebugRenderPlugin;
 use oxidized_navigation::DetailMeshSettings;
 use oxidized_navigation::{
+    colliders::rapier::RapierCollider,
     debug_draw::{DrawNavMesh, DrawPath, OxidizedNavigationDebugDrawPlugin},
     query::{find_path, find_polygon_path, perform_string_pulling_on_path},
     tiles::NavMeshTiles,
@@ -36,7 +37,7 @@ fn main() {
                 }),
                 ..default()
             }),
-            OxidizedNavigationPlugin::<Collider>::new(
+            OxidizedNavigationPlugin::<RapierCollider>::new(
                 NavMeshSettings::from_agent_and_bounds(0.5, 1.9, 250.0, -10.0)
                     .with_max_tile_generation_tasks(Some(NonZeroU16::MIN))
                     .with_experimental_detail_mesh_generation(DetailMeshSettings {

--- a/examples/rapier3d_multi_floor.rs
+++ b/examples/rapier3d_multi_floor.rs
@@ -15,6 +15,7 @@ use bevy::{
 use bevy::tasks::futures_lite::future;
 use bevy_rapier3d::prelude::{Collider, NoUserData, RapierPhysicsPlugin};
 use oxidized_navigation::{
+    colliders::rapier::RapierCollider,
     debug_draw::{DrawNavMesh, DrawPath, OxidizedNavigationDebugDrawPlugin},
     query::{find_path, find_polygon_path, perform_string_pulling_on_path},
     tiles::NavMeshTiles,
@@ -32,9 +33,9 @@ fn main() {
                 }),
                 ..default()
             }),
-            OxidizedNavigationPlugin::<Collider>::new(NavMeshSettings::from_agent_and_bounds(
-                0.5, 1.9, 250.0, -1.0,
-            )),
+            OxidizedNavigationPlugin::<RapierCollider>::new(
+                NavMeshSettings::from_agent_and_bounds(0.5, 1.9, 250.0, -1.0),
+            ),
             OxidizedNavigationDebugDrawPlugin,
             // The rapier plugin needs to be added for the scales of colliders to be correct if the scale of the entity is not uniformly 1.
             // An example of this is the "Thin Wall" in [setup_world_system]. If you remove this plugin, it will not appear correctly.

--- a/src/colliders/avian.rs
+++ b/src/colliders/avian.rs
@@ -2,13 +2,17 @@ use parry3d::{bounding_volume::Aabb, shape::TypedShape};
 
 use super::OxidizedCollider;
 
+pub struct AvianCollider;
+
 /// This is only compiled and available when the "avian" feature is enabled.
-impl OxidizedCollider for avian3d::prelude::Collider {
-    fn oxidized_into_typed_shape(&self) -> TypedShape {
-        self.shape_scaled().as_typed_shape()
+impl OxidizedCollider for AvianCollider {
+    type Component = avian3d::prelude::Collider;
+
+    fn oxidized_into_typed_shape(collider: &avian3d::prelude::Collider) -> TypedShape {
+        collider.shape_scaled().as_typed_shape()
     }
 
-    fn oxidized_compute_local_aabb(&self) -> Aabb {
-        self.shape_scaled().compute_local_aabb()
+    fn oxidized_compute_local_aabb(collider: &avian3d::prelude::Collider) -> Aabb {
+        collider.shape_scaled().compute_local_aabb()
     }
 }

--- a/src/colliders/mod.rs
+++ b/src/colliders/mod.rs
@@ -1,19 +1,23 @@
-use bevy::prelude::Component;
+use bevy::ecs::component::Component;
 
 #[cfg(feature = "avian")]
 pub mod avian;
 #[cfg(feature = "rapier")]
 pub mod rapier;
 
-/// The trait that is required to implement for the collider component that you want to use with oxidized-navigation.
+/// The trait that is required to implement for the collider that you want to use with oxidized-navigation.
 /// Essentially it allows you to use any bevy component that contains a `parry3d::shape::SharedShape` as a collider.
 ///
-/// This trait is already implemented for `bevy_rapier3d::prelude::Collider` and `avian::prelude::Collider`.
+/// This trait may be implemented directly on the component (though `OxidizedCollider::Component` must still be specified),
+/// or may be implemented on a different (foreign) type. This is already done with `avian3d` and `bevy_rapier3d`` colliders,
+/// with AvianCollider and RapierCollider respectively.
 ///
 /// See the parry3d example for how to implement this trait for a custom component that wraps a `parry3d::shape::SharedShape`.
-pub trait OxidizedCollider: Component {
-    // Names are changed to avoid conflicting with the function calls on a `parry3d::shape::SharedShape`.
-    fn oxidized_into_typed_shape(&self) -> parry3d::shape::TypedShape;
+pub trait OxidizedCollider: 'static {
+    type Component: Component;
 
-    fn oxidized_compute_local_aabb(&self) -> parry3d::bounding_volume::Aabb;
+    // Names are changed to avoid conflicting with the function calls on a `parry3d::shape::SharedShape`.
+    fn oxidized_into_typed_shape(item: &Self::Component) -> parry3d::shape::TypedShape;
+
+    fn oxidized_compute_local_aabb(item: &Self::Component) -> parry3d::bounding_volume::Aabb;
 }

--- a/src/colliders/rapier.rs
+++ b/src/colliders/rapier.rs
@@ -2,13 +2,17 @@ use parry3d::{bounding_volume::Aabb, shape::TypedShape};
 
 use super::OxidizedCollider;
 
+pub struct RapierCollider;
+
 /// This is only compiled and available when the "rapier" feature is enabled.
-impl OxidizedCollider for bevy_rapier3d::prelude::Collider {
-    fn oxidized_into_typed_shape(&self) -> TypedShape {
-        self.raw.as_typed_shape()
+impl OxidizedCollider for RapierCollider {
+    type Component = bevy_rapier3d::prelude::Collider;
+
+    fn oxidized_into_typed_shape(collider: &bevy_rapier3d::prelude::Collider) -> TypedShape {
+        collider.raw.as_typed_shape()
     }
 
-    fn oxidized_compute_local_aabb(&self) -> Aabb {
-        self.raw.compute_local_aabb()
+    fn oxidized_compute_local_aabb(collider: &bevy_rapier3d::prelude::Collider) -> Aabb {
+        collider.raw.compute_local_aabb()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub enum OxidizedNavigation {
 pub struct OxidizedNavigationPlugin<ColliderComponent> {
     pub settings: NavMeshSettings,
     schedule: Interned<dyn ScheduleLabel>,
-    _collider_type: PhantomData<ColliderComponent>,
+    _collider_type: PhantomData<fn() -> ColliderComponent>,
 }
 
 impl<C> OxidizedNavigationPlugin<C>
@@ -110,7 +110,7 @@ where
         OxidizedNavigationPlugin::<C> {
             settings,
             schedule: RunFixedMainLoop.intern(),
-            _collider_type: PhantomData::<C>,
+            _collider_type: PhantomData,
         }
     }
 
@@ -123,10 +123,7 @@ where
     }
 }
 
-impl<C> Plugin for OxidizedNavigationPlugin<C>
-where
-    C: OxidizedCollider,
-{
+impl<C: OxidizedCollider> Plugin for OxidizedNavigationPlugin<C> {
     fn build(&self, app: &mut App) {
         app.insert_resource(self.settings.clone());
 
@@ -495,82 +492,83 @@ fn update_navmesh_affectors_system<C: OxidizedCollider>(
     mut tile_affectors: ResMut<TileAffectors>,
     mut affector_relations: ResMut<NavMeshAffectorRelations>,
     mut dirty_tiles: ResMut<DirtyTiles>,
-    mut query: Query<(Entity, &C, &GlobalTransform), NavmeshAffectorChangedQueryFilter<C>>,
+    query: Query<
+        (Entity, &C::Component, &GlobalTransform),
+        NavmeshAffectorChangedQueryFilter<C::Component>,
+    >,
 ) {
     // Expand by 2 * walkable_radius to match with erode_walkable_area.
     let border_expansion =
         f32::from(nav_mesh_settings.walkable_radius * 2) * nav_mesh_settings.cell_width;
 
-    query
-        .iter_mut()
-        .for_each(|(e, collider, global_transform)| {
-            let transform = global_transform.compute_transform();
-            let iso = Isometry::new(
-                transform.translation.into(),
-                transform.rotation.to_scaled_axis().into(),
-            );
-            let local_aabb = collider.oxidized_compute_local_aabb();
-            let aabb = local_aabb
-                .scaled(&Vector3::new(
-                    transform.scale.x,
-                    transform.scale.y,
-                    transform.scale.z,
-                ))
-                .transform_by(&iso);
+    query.iter().for_each(|(e, collider, global_transform)| {
+        let transform = global_transform.compute_transform();
+        let iso = Isometry::new(
+            transform.translation.into(),
+            transform.rotation.to_scaled_axis().into(),
+        );
+        let local_aabb = C::oxidized_compute_local_aabb(&collider);
+        let aabb = local_aabb
+            .scaled(&Vector3::new(
+                transform.scale.x,
+                transform.scale.y,
+                transform.scale.z,
+            ))
+            .transform_by(&iso);
 
-            let min_vec = Vec2::new(
-                aabb.mins.x - border_expansion,
-                aabb.mins.z - border_expansion,
-            );
-            let min_tile = nav_mesh_settings.get_tile_containing_position(min_vec);
+        let min_vec = Vec2::new(
+            aabb.mins.x - border_expansion,
+            aabb.mins.z - border_expansion,
+        );
+        let min_tile = nav_mesh_settings.get_tile_containing_position(min_vec);
 
-            let max_vec = Vec2::new(
-                aabb.maxs.x + border_expansion,
-                aabb.maxs.z + border_expansion,
-            );
-            let max_tile = nav_mesh_settings.get_tile_containing_position(max_vec);
+        let max_vec = Vec2::new(
+            aabb.maxs.x + border_expansion,
+            aabb.maxs.z + border_expansion,
+        );
+        let max_tile = nav_mesh_settings.get_tile_containing_position(max_vec);
 
-            let relation = if let Some(relation) = affector_relations.0.get_mut(&e) {
-                // Remove from previous.
-                for old_tile in relation.iter().filter(|tile_coord| {
-                    min_tile.x > tile_coord.x
-                        || min_tile.y > tile_coord.y
-                        || max_tile.x < tile_coord.x
-                        || max_tile.y < tile_coord.y
-                }) {
-                    if let Some(affectors) = tile_affectors.get_mut(old_tile) {
-                        affectors.remove(&e);
-                        dirty_tiles.0.insert(*old_tile);
-                    }
-                }
-                relation.clear();
-
-                relation
-            } else {
-                affector_relations
-                    .0
-                    .insert_unique_unchecked(e, SmallVec::default())
-                    .1
-            };
-
-            for x in min_tile.x..=max_tile.x {
-                for y in min_tile.y..=max_tile.y {
-                    let tile_coord = UVec2::new(x, y);
-
-                    let affectors = if let Some(affectors) = tile_affectors.get_mut(&tile_coord) {
-                        affectors
-                    } else {
-                        tile_affectors
-                            .insert_unique_unchecked(tile_coord, HashSet::default())
-                            .1
-                    };
-                    affectors.insert(e);
-
-                    relation.push(tile_coord);
-                    dirty_tiles.0.insert(tile_coord);
+        let relation = if let Some(relation) = affector_relations.0.get_mut(&e) {
+            // Remove from previous.
+            for old_tile in relation.iter().filter(|tile_coord| {
+                min_tile.x > tile_coord.x
+                    || min_tile.y > tile_coord.y
+                    || max_tile.x < tile_coord.x
+                    || max_tile.y < tile_coord.y
+            }) {
+                if let Some(affectors) = tile_affectors.get_mut(old_tile) {
+                    affectors.remove(&e);
+                    dirty_tiles.0.insert(*old_tile);
                 }
             }
-        });
+            relation.clear();
+
+            relation
+        } else {
+            affector_relations
+                .0
+                .insert_unique_unchecked(e, SmallVec::default())
+                .1
+        };
+
+        for x in min_tile.x..=max_tile.x {
+            for y in min_tile.y..=max_tile.y {
+                let tile_coord = UVec2::new(x, y);
+
+                let affectors = if let Some(affectors) = tile_affectors.get_mut(&tile_coord) {
+                    affectors
+                } else {
+                    tile_affectors
+                        .insert_unique_unchecked(tile_coord, HashSet::default())
+                        .1
+                };
+                affectors.insert(e);
+
+                relation.push(tile_coord);
+                dirty_tiles.0.insert(tile_coord);
+            }
+        }
+    });
 }
 
 fn handle_removed_affectors_system(
@@ -612,7 +610,12 @@ fn send_tile_rebuild_tasks_system<C: OxidizedCollider>(
     nav_mesh: Res<NavMesh>,
     tile_affectors: Res<TileAffectors>,
     collider_query: Query<
-        (Entity, &C, &GlobalTransform, Option<&NavMeshAreaType>),
+        (
+            Entity,
+            &C::Component,
+            &GlobalTransform,
+            Option<&NavMeshAreaType>,
+        ),
         With<NavMeshAffector>,
     >,
 ) {
@@ -664,7 +667,7 @@ fn send_tile_rebuild_tasks_system<C: OxidizedCollider>(
         {
             let area = nav_mesh_affector.map_or(Some(Area(0)), |area_type| area_type.0);
 
-            let geometry_result = get_geometry_type(collider.oxidized_into_typed_shape());
+            let geometry_result = get_geometry_type(C::oxidized_into_typed_shape(&collider));
             let transform = global_transform.compute_transform();
             handle_geometry_result(
                 geometry_result,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,6 +487,7 @@ type NavmeshAffectorChangedQueryFilter<C> = (
     With<NavMeshAffector>,
 );
 
+#[expect(clippy::type_complexity)]
 fn update_navmesh_affectors_system<C: OxidizedCollider>(
     nav_mesh_settings: Res<NavMeshSettings>,
     mut tile_affectors: ResMut<TileAffectors>,
@@ -507,7 +508,7 @@ fn update_navmesh_affectors_system<C: OxidizedCollider>(
             transform.translation.into(),
             transform.rotation.to_scaled_axis().into(),
         );
-        let local_aabb = C::oxidized_compute_local_aabb(&collider);
+        let local_aabb = C::oxidized_compute_local_aabb(collider);
         let aabb = local_aabb
             .scaled(&Vector3::new(
                 transform.scale.x,
@@ -600,6 +601,7 @@ fn can_generate_new_tiles(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[expect(clippy::type_complexity)]
 fn send_tile_rebuild_tasks_system<C: OxidizedCollider>(
     mut active_generation_tasks: ResMut<ActiveGenerationTasks>,
     mut generation_ticker: ResMut<GenerationTicker>,
@@ -667,7 +669,7 @@ fn send_tile_rebuild_tasks_system<C: OxidizedCollider>(
         {
             let area = nav_mesh_affector.map_or(Some(Area(0)), |area_type| area_type.0);
 
-            let geometry_result = get_geometry_type(C::oxidized_into_typed_shape(&collider));
+            let geometry_result = get_geometry_type(C::oxidized_into_typed_shape(collider));
             let transform = global_transform.compute_transform();
             handle_geometry_result(
                 geometry_result,

--- a/tests/avian.rs
+++ b/tests/avian.rs
@@ -11,6 +11,7 @@ use bevy::{
     utils::{HashMap, RandomState},
 };
 use oxidized_navigation::{
+    colliders::avian::AvianCollider,
     query::{find_path, FindPathError},
     tiles::{NavMeshTile, NavMeshTiles},
     ActiveGenerationTasks, NavMesh, NavMeshAffector, NavMeshSettings, OxidizedNavigationPlugin,
@@ -236,7 +237,7 @@ impl TestApp for App {
         app.add_plugins((
             MinimalPlugins,
             TransformPlugin,
-            OxidizedNavigationPlugin::<Collider>::new(NavMeshSettings {
+            OxidizedNavigationPlugin::<AvianCollider>::new(NavMeshSettings {
                 cell_width: 0.25,
                 cell_height: 0.1,
                 tile_width: NonZeroU16::new(100).unwrap(),

--- a/tests/parry3d.rs
+++ b/tests/parry3d.rs
@@ -19,12 +19,14 @@ struct MyParryCollider {
 }
 
 impl OxidizedCollider for MyParryCollider {
-    fn oxidized_into_typed_shape(&self) -> TypedShape {
-        self.collider.as_typed_shape()
+    type Component = Self;
+
+    fn oxidized_into_typed_shape(collider: &Self) -> TypedShape {
+        collider.collider.as_typed_shape()
     }
 
-    fn oxidized_compute_local_aabb(&self) -> Aabb {
-        self.collider.compute_local_aabb()
+    fn oxidized_compute_local_aabb(collider: &Self) -> Aabb {
+        collider.collider.compute_local_aabb()
     }
 }
 

--- a/tests/rapier3d.rs
+++ b/tests/rapier3d.rs
@@ -3,8 +3,8 @@ use std::{num::NonZeroU16, time::Duration};
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::{Collider, NoUserData, RapierPhysicsPlugin};
 use oxidized_navigation::{
-    query::find_path, ActiveGenerationTasks, NavMesh, NavMeshAffector, NavMeshSettings,
-    OxidizedNavigationPlugin,
+    colliders::rapier::RapierCollider, query::find_path, ActiveGenerationTasks, NavMesh,
+    NavMeshAffector, NavMeshSettings, OxidizedNavigationPlugin,
 };
 
 const TIMEOUT_DURATION: Duration = Duration::new(15, 0);
@@ -61,7 +61,7 @@ fn setup_app(app: &mut App) {
     app.add_plugins((
         MinimalPlugins,
         TransformPlugin,
-        OxidizedNavigationPlugin::<Collider>::new(NavMeshSettings {
+        OxidizedNavigationPlugin::<RapierCollider>::new(NavMeshSettings {
             cell_width: 0.25,
             cell_height: 0.1,
             tile_width: NonZeroU16::new(100).unwrap(),


### PR DESCRIPTION
This undeniably makes the trait more complicated (trying to figure out the lifetimes was quite the headache). However we now have a setup where we can separate the AvianCollider and RapierCollider structs into their own crates.